### PR TITLE
Add ACATS report package compilation step to test runner

### DIFF
--- a/run_acats.sh
+++ b/run_acats.sh
@@ -12,6 +12,12 @@ NPROC=${NPROC:-$(nproc 32>/dev/null || echo 32)}
 START_MS=$(date +%s%3N)
 mkdir -p test_results acats_logs
 
+# ── Compile ACATS report package if needed ──────────────────────────────
+if [[ ! -f acats/report.ll ]] || [[ acats/report.adb -nt acats/report.ll ]]; then
+    ./ada83 acats/report.adb > acats/report.ll 2>/dev/null || {
+        echo "FATAL: cannot compile acats/report.adb"; exit 1; }
+fi
+
 # ── Helpers ───────────────────────────────────────────────────────────────
 
 pct(){ ((${2:-0}>0)) && printf %d $((100*$1/$2)) || printf 0; }


### PR DESCRIPTION
## Summary
This PR adds an automatic compilation step for the ACATS report package to the test runner, ensuring the report module is available before running tests.

## Key Changes
- **ada83.c**: Significant refactoring and enhancements (+843/-164 lines) to support compilation of the ACATS report package
- **run_acats.sh**: Added pre-flight compilation check that:
  - Compiles `acats/report.adb` to `acats/report.ll` if the compiled version doesn't exist or is out of date
  - Uses the updated `ada83` compiler to generate the LLVM IR output
  - Fails fast with a clear error message if compilation fails, preventing subsequent test execution with missing dependencies

## Implementation Details
The compilation step is placed early in the test runner (after directory setup but before test execution) to catch compilation errors immediately. The check uses file modification time comparison (`-nt` flag) to avoid unnecessary recompilation when the source hasn't changed, improving test runner efficiency.

https://claude.ai/code/session_01CneR9gJJrxVPP2hqhrVRp1