### PR TITLE
Fix Windows path handling and test infrastructure issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+ada83
+ada83.exe
+ada83.vsix
+staging/
+bin-*.zip.new
+
+acats/
+acats_logs/
+test_results/
+acats.baseline

--- a/ada83.c
+++ b/ada83.c
@@ -129,6 +129,25 @@ int Host_Processor_Count () {
   return count > 1 ? (int) count : 1;
 }
 
+#ifdef _WIN32
+  #define HOST_DIRECTORY_SEPARATORS "/\\"
+#else
+  #define HOST_DIRECTORY_SEPARATORS "/"
+#endif
+
+const char *Host_Path_Split (const char *path) {
+  const char *last = NULL;
+  for (const char *scan = path;
+       (scan = strpbrk (scan, HOST_DIRECTORY_SEPARATORS));
+       scan++)
+    last = scan;
+  return last;
+}
+
+bool Host_Path_Separates (char character) {
+  return character and strchr (HOST_DIRECTORY_SEPARATORS, character);
+}
+
 bool Host_Executable_Path (char *buffer, size_t size, const char *invoked_as) {
 #if defined(_WIN32)
   DWORD written = GetModuleFileNameA (NULL, buffer, (DWORD) size);
@@ -6817,7 +6836,7 @@ const char *Add_Include_Path (const char *directory);
 bool        Is_Directory   (const char *path, char *out,
                               size_t out_size);
 const char *Take_Base_Name (const char *path) {
-  const char *slash = strrchr (path, '/');
+  const char *slash = Host_Path_Split (path);
   return slash ? slash + 1 : path;
 }
 char *Try_Read_Ext         (const char *base, const char *ext);
@@ -59018,7 +59037,8 @@ char *Try_Read_Ext (const char *base, const char *ext) {
 void Build_Include_Path_Filename (Slice name, u32 index, char *out, size_t out_size) {
   size_t base_len = strlen (Include_Paths[index]);
   snprintf (out, out_size, "%s%s%.*s", Include_Paths[index],
-       (base_len > 0 and Include_Paths[index][base_len-1] != '/') ? "/" : "",
+       (base_len and not Host_Path_Separates (Include_Paths[index][base_len-1]))
+         ? "/" : "",
        (int)name.length, name.data);
   for (char *cursor = out + base_len; *cursor; cursor++)
     if (*cursor >= 'A' and *cursor <= 'Z') *cursor = *cursor - 'A' + 'a';
@@ -59207,7 +59227,7 @@ const char *Add_Include_Path (const char *directory) {
 }
 
 bool Is_Directory (const char *path, char *out, size_t out_size) {
-  const char *slash = strrchr (path, '/');
+  const char *slash = Host_Path_Split (path);
   if (not slash) {
     if (out_size < 2) return false;
     out[0] = '.';
@@ -60411,7 +60431,7 @@ void Compile_Job_Start (Compile_Job *job, const char *input_path,
   job->exit_status = 0;
   job->worker      = HOST_PROCESS_NONE;
 
-  const char *slash = strrchr (input_path, '/');
+  const char *slash = Host_Path_Split (input_path);
   const char *dot   = strrchr (input_path, '.');
   size_t stem = (dot and (not slash or dot > slash))
               ? (size_t) (dot - input_path) : strlen (input_path);

--- a/checklist.txt
+++ b/checklist.txt
@@ -1,0 +1,96 @@
+================================================================================
+ada83 — Windows test-failure investigation and fix checklist
+================================================================================
+
+--------------------------------------------------------------------------------
+THE PROMPT (verbatim)
+--------------------------------------------------------------------------------
+Currently the test script fails with the following results under windows:
+
+```
+
+ CLASS                    pass   fail   skip  total    rate
+ ---------------------- ------ ------ ------ ------ -------
+ A  Acceptance               0      0    140    140      0%
+ B  Illegality            1343      7      0   1350     99%
+ C  Executable               0      0   1973   1973      0%
+ D  Numerics                 0      0     17     17      0%
+ E  Inspection               1      0     33     34      2%
+ L  Post-compilation        47      0      0     47    100%
+ ---------------------- ------ ------ ------ ------ -------
+ TOTAL                    1391      7   2163   3561     39%
+
+========================================
+
+```
+
+In the pursuit of high-quality code (low line count (e.g. low undue
+complexity) and high feature/correctness) - refactor and fix ada83.c all
+tests completely with much better Haskell-like C99 and smart
+code-golfing with, ironically, textbook "Literate Programming" style - NO COMMENTS THOUGH.
+
+Do NOT skip around - when you encounter a complex problem look at it as an
+opportunity to finally attack a big issue. Remember to follow the flow
+upstream to avoid hacking up the expander.
+
+Create a file to track everything called "checklist.txt" and include this
+prompt in it.
+
+Follow-up: "it could be failing for all platforms - just figure out quickly
+what the problem is instead of stalling on full tests - have a better concept
+of time please"
+
+--------------------------------------------------------------------------------
+DIAGNOSIS
+--------------------------------------------------------------------------------
+The reported table is not 2163 distinct compiler bugs.  It is one missing
+tool reported 2163 times.
+
+test.sh only probes for `timeout`.  It never probes for `llvm-link` or `lli`,
+which every A/C/D/E test needs.  When `llvm-link` cannot run, link_program()
+returns non-zero, LINK_STATUS is set to `unresolved`, and A/C/D/E each print
+`skip ... BIND:unresolved_symbols`.  L prints `pass` on that same path
+because every L branch prints pass.  B never links at all, so B is the only
+class whose numbers are real.
+
+Reproduced exactly on Linux by shadowing the two tools with `exit 127` stubs:
+
+    A  Acceptance   0 pass  0 fail  24 skip   0%
+
+The signature matches the report term for term:
+    - A/C/D/E: 100% skip, 0 fail          (link step never runs)
+    - L:       100% pass                  (pass on every branch)
+    - B:       real numbers               (never links)
+    - E:       1 pass                     (a documented-reject, not a run)
+
+The Windows-only IR was checked directly and is valid: the naked
+__ada_setjmp / __ada_longjmp pair assembles and lowers cleanly under
+llvm-as/llc with `x86_64-w64-windows-gnu`.  bin-windows.zip ships LLVM-C.dll
+for the native back end but no llvm-link.exe / lli.exe, so a Windows user
+following the README has the compiler and not the harness tools.
+
+The 7 class-B failures are the same shape one step down.  compile_set() and
+the B arm both capped a compile at a hard-coded 4 seconds.  A compile that
+overruns the cap exits non-zero with an empty .err, so the B arm sees the
+rejection it wants but none of the diagnostics, scores 0/N and prints
+LOW_COVERAGE.  4 seconds is a property of the host, not of the compiler; the
+seven slowest B compiles fall off a slower one.
+
+--------------------------------------------------------------------------------
+TASKS
+--------------------------------------------------------------------------------
+[x] Reproduce the reported table on a non-Windows host
+[x] Confirm the Windows-only emitted IR is well-formed
+[x] Full Linux ACATS baseline run — 3561 / 3561, so nothing here is a
+    front-end or back-end defect
+[x] test.sh: probe for llvm-link/lli up front and fail loudly, as it already
+    does for `timeout`, instead of laundering the absence into 2163 skips
+[x] test.sh: name the compile cap COMPILE_TIMEOUT, default it to the same 30
+    seconds the run cap uses, and export it, so a slower host does not turn
+    correct diagnostics into LOW_COVERAGE
+[x] ada83.c: Is_Directory, Take_Base_Name and Compile_Job_Start each split a
+    path on '/' alone, so on Windows GetModuleFileNameA's "C:\dir\ada83.exe"
+    yields "." and the shipped compiler cannot find ada83-runtime.ada beside
+    itself.  One Host_Path_Split over HOST_DIRECTORY_SEPARATORS now serves
+    all three, and Host_Path_Separates serves the include-path join.
+[x] Re-run: a2 24/24, b2 100/100, c34 67/67, d 17/17, e 34/34, l 47/47

--- a/test.sh
+++ b/test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 NPROC=${JOBS:-${NPROC:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)}}
 TEST_TIMEOUT=${TEST_TIMEOUT:-30}
+COMPILE_TIMEOUT=${COMPILE_TIMEOUT:-30}
 LINK_TIMEOUT=${LINK_TIMEOUT:-20}
 BASELINE=${BASELINE:-acats.baseline}
 
@@ -12,6 +13,18 @@ TIMEOUT=$(command -v timeout || command -v gtimeout) || {
     exit 1
 }
 export TIMEOUT
+
+for tool in llvm-link lli; do
+    command -v "$tool" >/dev/null || {
+        echo "FATAL: no '$tool' command found" >&2
+        echo "       classes A, C, D and E link and run what they compile," >&2
+        echo "       and without it every one of them reports as skipped" >&2
+        echo "       Debian/Ubuntu: apt-get install llvm" >&2
+        echo "       macOS:         brew install llvm" >&2
+        echo "       Windows:       winget install LLVM.LLVM" >&2
+        exit 1
+    }
+done
 
 now_ms(){
     local stamp
@@ -65,7 +78,7 @@ compile_set(){
     COMPILE_FAILED=""
     for part in "${COMPILE_FILES[@]}"; do
         pn=$(basename "$part" .ada)
-        if ! "$TIMEOUT" 4 ./ada83 --ir "$part" -o $lib/$pn.ll >/dev/null 2>$LOGS_DIR/$n.err; then
+        if ! "$TIMEOUT" "$COMPILE_TIMEOUT" ./ada83 --ir "$part" -o $lib/$pn.ll >/dev/null 2>$LOGS_DIR/$n.err; then
             if [[ $pn == "$n" ]]; then
                 COMPILE_FAILED=$pn
                 return 1
@@ -243,7 +256,7 @@ run_one(){
                     fi
                 fi
             done < "$part"
-            if "$TIMEOUT" 4 ./ada83 --ir "$part" -o "$lib/${pn%.ada}.ll" \
+            if "$TIMEOUT" "$COMPILE_TIMEOUT" ./ada83 --ir "$part" -o "$lib/${pn%.ada}.ll" \
                  >/dev/null 2>$LOGS_DIR/$n.$pn.err; then :; else
                 rejected=yes
             fi
@@ -340,7 +353,7 @@ run_one(){
 ROOT=$PWD
 export ROOT
 export -f run_one gather_files compile_set run_in_lib link_program run_continuity_creators pct
-export START_MS TEST_TIMEOUT LINK_TIMEOUT
+export START_MS TEST_TIMEOUT LINK_TIMEOUT COMPILE_TIMEOUT
 
 run_one_timed(){
     local f=$1 n=$(basename "$1" .ada) q


### PR DESCRIPTION
## Summary
This PR fixes critical issues preventing the test suite from running on Windows and addresses false test failures caused by missing LLVM tools and hardcoded compile timeouts.

## Key Changes

- **Windows path separator support**: Added `Host_Path_Split()` and `Host_Path_Separates()` functions to handle both forward slashes and backslashes as path separators on Windows. Updated `Take_Base_Name()`, `Is_Directory()`, and `Compile_Job_Start()` to use the new cross-platform path splitting logic instead of hardcoded `/` characters.

- **Test infrastructure validation**: Enhanced `test.sh` to probe for required LLVM tools (`llvm-link` and `lli`) at startup and fail with clear error messages if they're missing, rather than silently reporting 2163 skipped tests.

- **Configurable compile timeout**: Introduced `COMPILE_TIMEOUT` environment variable (defaulting to 30 seconds, matching the run timeout) to replace the hardcoded 4-second compile limit. This prevents correct diagnostics from being masked as `LOW_COVERAGE` on slower hosts.

- **Build artifacts**: Added `.gitignore` to exclude build outputs, test logs, and baseline files.

- **Documentation**: Created `checklist.txt` documenting the diagnosis and resolution of the Windows test failures.

## Implementation Details

The `Host_Path_Split()` function uses `strpbrk()` to find the last occurrence of any path separator character defined by the platform-specific `HOST_DIRECTORY_SEPARATORS` macro. This unified approach eliminates the need for multiple `strrchr()` calls with hardcoded separators throughout the codebase.

The test infrastructure changes ensure that missing tools are caught immediately with actionable error messages for different platforms (Debian/Ubuntu, macOS, Windows) rather than producing misleading test results.

https://claude.ai/code/session_019VrqmQztMkQbE14UAXLDnv