### PR TITLE
Fix - CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,8 @@
 name: build
 
-# The shared body of the three per-platform CI workflows. They are separate
-# workflows so that each platform gets its own status badge, which a single
-# matrix job cannot give you: a badge names one workflow, not one leg of it.
-# The steps live here so there is only ever one copy to keep correct.
+# Shared body of the three per-platform CI workflows. They are separate
+# workflows so each platform gets its own badge; a badge names a workflow, not
+# one leg of a matrix.
 
 on:
   workflow_call:
@@ -24,8 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # lli and llvm-link are what test.sh runs the suite with. None of this
-      # affects how ada83 itself is compiled; that is the build step below.
+      # lli and llvm-link are what test.sh runs the suite with.
       - name: Install test tools (Linux)
         if: inputs.platform == 'linux'
         shell: bash
@@ -39,11 +37,9 @@ jobs:
           done
           command -v lli && command -v llvm-link
 
-      # Two things macOS does not ship that test.sh needs: timeout(1), which it
-      # accepts as coreutils' gtimeout, and a bash newer than the 3.2 in /bin,
-      # which lacks the associative arrays, mapfile and ${x,,} the suite uses.
-      # Its workers run as bare `bash -c`, so the newer bash has to come first
-      # on PATH rather than merely be installed.
+      # macOS has no timeout(1) — test.sh accepts coreutils' gtimeout — and its
+      # /bin/bash is 3.2, too old for the suite. Workers run as bare `bash -c`,
+      # so the newer bash must come first on PATH.
       - name: Install test tools (macOS)
         if: inputs.platform == 'macos'
         shell: bash
@@ -52,14 +48,11 @@ jobs:
           echo "$(brew --prefix)/bin"     >> "$GITHUB_PATH"
           echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
 
-      # release: false re-uses the MSYS2 already on the runner image at
-      # C:\msys64 instead of downloading and unpacking a second one. That
-      # install is only a bare base — no mingw64 packages, no unzip — so the
-      # pacman step below still does the real work, and update stays on because
-      # installing into a stale base is a partial upgrade.
-      # lli and llvm-link come from mingw-w64-x86_64-llvm and are what test.sh
-      # runs the suite with; neither Git Bash nor the image's own LLVM has
-      # them. unzip is not in base-devel, and test.sh wants it for tests.zip.
+      # release: false reuses the MSYS2 already on the image. clang and lld are
+      # the C driver ada83 links finished programs with: it emits thread-local
+      # storage as COFF weak externals, which GNU ld cannot resolve, so gcc
+      # fails every link with "relocation truncated to fit" against __ss_first
+      # and friends. unzip is not in base-devel.
       - name: Install test tools (Windows)
         if: inputs.platform == 'windows'
         uses: msys2/setup-msys2@v2
@@ -67,26 +60,25 @@ jobs:
           msystem: MINGW64
           release: false
           update: true
-          install: mingw-w64-x86_64-llvm base-devel unzip
+          install: >-
+            mingw-w64-x86_64-llvm
+            mingw-w64-x86_64-clang
+            mingw-w64-x86_64-lld
+            base-devel
+            unzip
 
       - name: Build (Linux/macOS)
         if: inputs.platform != 'windows'
         shell: bash
         run: make ada83
 
-      # make.bat is the documented Windows build. It is deliberately not run
-      # from the MSYS2 shell above, which is here only for the POSIX harness.
       - name: Build (Windows)
         if: inputs.platform == 'windows'
         shell: cmd
         run: make.bat
 
-      # ada83 looks for ada83-runtime.ada beside its own executable. The make
-      # targets leave the binary in bin-<platform>/ and the runtime at the repo
-      # root, so without this the compiler cannot read its own runtime and
-      # every unit that mentions TEXT_IO fails to compile. That shows up as
-      # thousands of skips rather than failures, and the illegality tests still
-      # pass, because a compiler that rejects everything rejects those too.
+      # ada83 looks for ada83-runtime.ada beside its own executable; the make
+      # targets leave the binary in bin-<platform>/ and the runtime at the root.
       - name: Place the runtime beside the compiler
         shell: bash
         run: |
@@ -102,87 +94,51 @@ jobs:
         shell: bash
         run: bash test.sh run all
 
-      # Under MSYS2 test.sh resolves HOST_TARGET to windows and picks up
-      # bin-windows/ada83.exe by itself, so nothing needs copying first.
-      #
-      # ada83 produces an executable by shelling out to a C driver — clang,
-      # zig cc, cc, then gcc. path-type is minimal, so the image's toolchain is
-      # invisible from in here and every link dies with "'clang' is not
-      # recognized as an internal or external command", which the harness
-      # reports as a skip rather than a failure. C:\mingw64 holds the same gcc
-      # that make.bat builds the compiler with.
       - name: Run ACATS (Windows)
         if: inputs.platform == 'windows'
         shell: msys2 {0}
-        run: |
-          export PATH="/c/mingw64/bin:$PATH"
-          command -v gcc
-          bash test.sh run all
+        run: bash test.sh run all
 
-      # `test.sh run` reports failures but always exits 0 — only `check` does
-      # otherwise, and that needs a per-platform baseline this repo does not
-      # carry. Without this step a wholly failing suite still shows a green
-      # badge, which is worse than no badge at all. It runs on failure too, so
-      # that a suite which died partway still says so in the job summary.
+      # `test.sh run` always exits 0, and a skipped test never ran at all, so
+      # both counts have to be checked or a wholly broken suite shows green.
       - name: Report and gate on the results
         if: always()
         shell: bash
         run: |
           set -euo pipefail
-          # `|| true` because no match makes ls exit 2, which would abort the
-          # step before it could report the more useful message below.
           summary=$(ls -t test_results/*/test_summary.txt 2>/dev/null | head -1 || true)
           if [[ -z $summary ]]; then
             echo "::error::the suite produced no summary; it did not run to completion"
             exit 1
           fi
-          {
-            echo "### ACATS — ${{ inputs.platform }}"
-            echo '```'
-            cat "$summary"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          { echo "### ACATS — ${{ inputs.platform }}"; echo '```'
+            cat "$summary"; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
           cat "$summary"
 
           failed=$(sed -n 's/.*[[:space:]]F=\([0-9]\{1,\}\).*/\1/p' "$summary")
           skipped=$(sed -n 's/.*[[:space:]]S=\([0-9]\{1,\}\).*/\1/p' "$summary")
           : "${failed:=0}" "${skipped:=0}"
+          (( failed || skipped )) || exit 0
 
-          # A skip is a test that never ran at all, because it would not
-          # compile, bind or link. Gating on failures alone would call a run
-          # green in which every executable test was skipped and only the
-          # compile-only classes reported anything.
-          # On a bad run the counts say nothing about why. test.sh sends the
-          # compiler's own diagnostics to per-test log files and reports only a
-          # category, so print the categories and then the actual text of the
-          # first few, which is what identifies the cause.
-          if (( failed > 0 || skipped > 0 )); then
-            results=$(ls -t test_results/*/results.tsv 2>/dev/null | head -1 || true)
-            logs=$(ls -td acats_logs/*/ 2>/dev/null | head -1 || true)
-            if [[ -n $results ]]; then
-              echo "categories, most common first:"
-              awk -F'\t' '$3 != "pass" { reason = $4; sub(/[:[].*/, "", reason);
-                                         print "  " $3 " " reason }' "$results" \
-                | sort | uniq -c | sort -rn | head
-              echo
-              echo "first few, with what the compiler actually said:"
-              # Counted inside awk rather than piped to head, which would close
-              # the pipe early and leave "awk: write error on /dev/stdout".
-              awk -F'\t' '$3 != "pass" && ++shown <= 3 { print $1 "\t" $3 "\t" $4 }' "$results" \
-              | while IFS=$'\t' read -r name result detail; do
-                  echo "  --- $name ($result) $detail"
-                  for stage in err bind link out; do
-                    [[ -s "$logs/$name.$stage" ]] || continue
-                    echo "      [$name.$stage]"
-                    head -6 "$logs/$name.$stage" | sed 's/^/        /'
-                  done
+          # test.sh reports only a category and sends the real diagnostics to
+          # per-test logs, so print those for the first few.
+          results=$(ls -t test_results/*/results.tsv 2>/dev/null | head -1 || true)
+          logs=$(ls -td acats_logs/*/ 2>/dev/null | head -1 || true)
+          if [[ -n $results ]]; then
+            awk -F'\t' '$3 != "pass" && ++n <= 3 { print $1 "\t" $4 }' "$results" \
+            | while IFS=$'\t' read -r name detail; do
+                echo "--- $name  $detail"
+                # Compiler diagnostics lead with the root cause; the bind and
+                # link logs end with it, after one line per driver tried.
+                for stage in err out; do
+                  [[ -s "$logs/$name.$stage" ]] || continue
+                  echo "  [$stage]"; head -6 "$logs/$name.$stage" | sed 's/^/    /'
                 done
-            fi
+                for stage in bind link; do
+                  [[ -s "$logs/$name.$stage" ]] || continue
+                  echo "  [$stage]"; tail -20 "$logs/$name.$stage" | sed 's/^/    /'
+                done
+              done
           fi
-          if (( failed > 0 )); then
-            echo "::error::$failed ACATS test(s) failed on ${{ inputs.platform }}"
-          fi
-          if (( skipped > 0 )); then
-            echo "::error::$skipped ACATS test(s) never ran on ${{ inputs.platform }}; they could not compile, bind or link"
-          fi
-          (( failed == 0 && skipped == 0 ))
+          echo "::error::${{ inputs.platform }}: $failed failed, $skipped never ran"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 name: Release
 
-# A release is cut by pushing a tag on main. Nothing is published on ordinary
-# pushes — there are no nightlies.
-#
-# Versioning is classic two-part (0.9, 1.0, 1.1), not semantic versioning, and
-# ada83.c holds the number: ADA83_VERSION_MAJOR / _MINOR, read by
-# .github/version.sh. A tag is only published if it names that version, sits
-# on main, and has not been released already — see the `verify` job.
+# A release is cut by pushing a tag on main; nothing publishes on ordinary
+# pushes. Versioning is classic two-part (0.9, 1.0, 1.1), and ada83.c holds the
+# number in ADA83_VERSION_MAJOR / _MINOR, read by .github/version.sh.
 
 on:
   push:
@@ -16,8 +12,6 @@ permissions:
   contents: write
 
 jobs:
-  # Cheap gate: refuse to spend three build machines on a tag that would
-  # publish a binary whose --version disagrees with the tag name.
   verify:
     name: verify tag
     runs-on: ubuntu-latest
@@ -51,13 +45,9 @@ jobs:
             exit 1
           fi
 
-          echo "$tag_name verified against ada83.c and main."
-
-  # One packaging job per platform, each on its own native runner. `make
-  # package` builds the compiler, the platform artwork and the VS Code
-  # extension, then packs all of it into bin-<platform>.zip. The extension is
-  # deliberately not published on its own: every platform archive carries a
-  # copy.
+  # `make package` builds the compiler, the platform artwork and the VS Code
+  # extension, then packs bin-<platform>.zip. The extension is not published
+  # separately: every archive carries a copy.
   package:
     name: package (${{ matrix.platform }})
     needs: [verify]
@@ -75,33 +65,71 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # macOS builds arm64 and x86_64 slices and lipos them into one binary;
-      # the makefile handles that from ARCHITECTURES_macos.
       - name: Package (Linux/macOS)
         if: matrix.platform != 'windows'
         shell: bash
         run: make package TARGET=${{ matrix.platform }}
 
-      # make.bat unpacks LLVM-C.dll and friends out of the committed
-      # bin-windows.zip, then repacks it with the freshly built exe.
       - name: Package (Windows)
         if: matrix.platform == 'windows'
         shell: cmd
         run: make.bat package
 
-      # The binary must report the version the tag promised. Cheap insurance
-      # against a stale checkout or a build that picked up the wrong source.
-      - name: Check --version against the tag
+      # The archives are built with different flags from CI, and on macOS as a
+      # universal binary CI never produces, so what ships is not what the suite
+      # ran against. Unpack it and take the compiler through a real compile,
+      # link and run.
+      - name: Check the packaged archive
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${{ matrix.platform }}" == windows ]]; then
-            binary=bin-windows/ada83.exe
-          else
-            binary=bin-${{ matrix.platform }}/ada83
-          fi
-          "$binary" --version
-          "$binary" --version | grep -q "ada83 ${GITHUB_REF_NAME#v} "
+          rm -rf verify && mkdir verify
+          unzip -q bin-${{ matrix.platform }}.zip -d verify
+          cd verify
+
+          case "${{ matrix.platform }}" in
+            windows) compiler=./ada83.exe ;;
+            *)       compiler=./ada83 ;;
+          esac
+          chmod +x "$compiler" 2>/dev/null || true
+
+          "$compiler" --version
+          "$compiler" --version | grep -q "ada83 ${GITHUB_REF_NAME#v} "
+
+          printf '%s\n' \
+            'WITH TEXT_IO;' \
+            'PROCEDURE HELLO IS' \
+            'BEGIN' \
+            '   TEXT_IO.PUT_LINE ("packaged ada83 works");' \
+            'END HELLO;' > hello.adb
+          "$compiler" hello.adb -o hello
+          program=./hello
+          [[ -x $program ]] || program=./hello.exe
+          "$program" | grep -qx "packaged ada83 works"
+
+      # A universal binary missing a slice still runs on the machine that built
+      # it, so the only way to catch that is to ask.
+      - name: Check the macOS binary is universal
+        if: matrix.platform == 'macos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          archs=$(lipo -archs verify/ada83)
+          echo "slices: $archs"
+          for want in arm64 x86_64; do
+            grep -qw "$want" <<<"$archs" \
+              || { echo "::error::bin-macos.zip is missing the $want slice (has: $archs)"; exit 1; }
+          done
+
+      # ada83.exe loads LLVM-C.dll at run time; without it the archive is inert
+      # on any machine that does not already have LLVM.
+      - name: Check the Windows archive carries its DLLs
+        if: matrix.platform == 'windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          unzip -l bin-windows.zip | grep -qi 'LLVM-C\.dll' \
+            || { echo "::error::bin-windows.zip does not contain LLVM-C.dll"; exit 1; }
 
       - uses: actions/upload-artifact@v4
         with:

--- a/ada83-runtime.ada
+++ b/ada83-runtime.ada
@@ -327,7 +327,8 @@ package body Text_IO is
     Dummy : Integer;
     begin
       for I in 4..99 loop
-        if Same_External (I, Name) then
+        -- Only a file with pending output is flushable; see Reset below.
+        if Same_External (I, Name) and then File_Control_Blocks (I).Mode /= In_File then
           Dummy := C_Fflush (File_Control_Blocks (I).Stream);
         end if;
       end loop;
@@ -529,7 +530,13 @@ package body Text_IO is
         File_Control_Blocks (Table_Slot).Page_Active := False;
       end if;
       if File_Control_Blocks (Table_Slot).Shared and File_Control_Blocks (Table_Slot).Stream /= Null_Address then
-        Dummy := C_Fflush (File_Control_Blocks (Table_Slot).Stream);
+        -- Flushing a stream last used for reading is undefined in C. The
+        -- Windows runtime advances it to the end of what it had buffered,
+        -- which drags every other internal file sharing the stream to end of
+        -- file; the branches below reposition where a mode needs it.
+        if File_Control_Blocks (Table_Slot).Mode /= In_File then
+          Dummy := C_Fflush (File_Control_Blocks (Table_Slot).Stream);
+        end if;
         if Mode = In_File then
           null;
         elsif Mode = Out_File then

--- a/ada83.c
+++ b/ada83.c
@@ -281,6 +281,21 @@ double Raise_To_Power_Exact (double base, double exponent) {
   #define SIMD_GENERIC 1
 #endif
 
+/* LLVM's AArch64 backend does not lower @llvm.eh.sjlj.setjmp/longjmp: it
+   silently mis-selects them instead of refusing to compile, so a handler's
+   frame never actually lands on the chain and every exception on this
+   architecture looks unhandled at run time.  The hand-written naked-asm
+   __ada_setjmp/__ada_longjmp pair below (originally added for Windows,
+   where the intrinsics aren't usable either) sidesteps that: it is plain
+   AAPCS64 register spill/reload, so it works the same under macOS, Linux
+   or Windows on arm64.  */
+#ifdef SIMD_ARM64
+  #define ADA_SJLJ_NAKED 1
+#endif
+#ifdef _WIN32
+  #define ADA_SJLJ_NAKED 1
+#endif
+
 #define X86_64_DATA_LAYOUT(mangling)                                     \
   "e-m:" mangling "-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128"     \
   "-n8:16:32:64-S128"
@@ -34126,7 +34141,7 @@ Bound_Temps Emit_Bounds_From_Fat_Dim (u32 fat_ptr,
 
 u32 Emit_Sjlj_Setjmp (u32 jmp_buf) {
   cg->frame_resumed_by_longjmp = true;
-#ifdef _WIN32
+#ifdef ADA_SJLJ_NAKED
   return Emit_Call_Result ("" C_INT_TYPE " @__ada_setjmp(ptr %s)"
                            " returns_twice",
                            REG (jmp_buf));
@@ -52463,6 +52478,10 @@ void Emit_Runtime_Declarations () {
     "declare void @GetSystemTimeAsFileTime(ptr)\n"
     "declare void @Sleep(i32)\n"
 #else
+#ifdef __APPLE__
+    "declare ptr @pthread_self()\n"
+    "declare i64 @pthread_get_stacksize_np(ptr)\n"
+#endif
     "declare i32 @getrlimit(i32, ptr)\n"
     "declare i32 @nanosleep(ptr, ptr)\n"
     "declare i32 @clock_gettime(i32, ptr)\n"
@@ -53242,7 +53261,11 @@ void Emit_Runtime_Storage () {
     "  ret void\n"
     "}\n\n"
     "@__stk_anchor = linkonce_odr thread_local(initialexec) global i64 0\n"
-    "@__stk_limit  = linkonce_odr global i64 0\n"
+    /* thread_local: a plain global here would let whichever thread checks
+       first cache its stack size for every other thread too. That is wrong
+       on macOS, where pthread_create()'d task threads get a fixed 512 KiB
+       regardless of the process stack rlimit the main thread reports.  */
+    "@__stk_limit  = linkonce_odr thread_local(initialexec) global i64 0\n"
     "; stack probe, slow path: establishes @__stack_floor\n"
     "define linkonce_odr void @__ada_stack_check(i64 %size) nounwind noinline cold {\n"
     "entry:\n"
@@ -53267,6 +53290,14 @@ void Emit_Runtime_Storage () {
     "  %lo = load i64, ptr %lohi\n"
     "  %hi = load i64, ptr %hi_p\n"
     "  %l2 = sub i64 %hi, %lo\n"
+    "  store i64 %l2, ptr @__stk_limit\n"
+    "  br label %check\n"
+#elif defined(__APPLE__)
+    /* RLIMIT_STACK is a process-wide figure that only describes the main
+       thread; pthread_create() gives every task thread a fixed 512 KiB
+       stack regardless of it, so ask the thread for its own size instead.  */
+    "  %self = call ptr @pthread_self()\n"
+    "  %l2 = call i64 @pthread_get_stacksize_np(ptr %self)\n"
     "  store i64 %l2, ptr @__stk_limit\n"
     "  br label %check\n"
 #else
@@ -53719,7 +53750,7 @@ void Emit_Runtime_Rendezvous_Records () {
     "}\n\n");
 }
 
-#ifdef _WIN32
+#ifdef ADA_SJLJ_NAKED
 void Emit_Runtime_Setjmp () {
 #ifdef SIMD_X86_64
   Emit_Verbatim (
@@ -53791,7 +53822,7 @@ void Emit_Runtime_Setjmp () {
 #endif
 
 void Emit_Runtime_Raise () {
-#ifdef _WIN32
+#ifdef ADA_SJLJ_NAKED
   Emit_Runtime_Setjmp ();
 #endif
   Emit_Verbatim (
@@ -53805,7 +53836,7 @@ void Emit_Runtime_Raise () {
     "  br i1 %is_null, label %unhandled, label %jump\n"
     "jump:\n"
     "  %jb = getelementptr { ptr, [240 x i8] }, ptr %frame, i32 0, i32 1\n"
-#ifdef _WIN32
+#ifdef ADA_SJLJ_NAKED
     "  call void @__ada_longjmp(ptr %jb)\n"
 #else
     "  call void @llvm.eh.sjlj.longjmp(ptr %jb)\n"
@@ -60612,7 +60643,7 @@ bool Warning_Flags_From_Command_Line (const char *argument) {
 }
 
 #define ADA83_VERSION_MAJOR 0
-#define ADA83_VERSION_MINOR 10
+#define ADA83_VERSION_MINOR 11
 
 #define ADA83_VERSION_TEXT \
   "ada83 " TEXT_OF (ADA83_VERSION_MAJOR) "." TEXT_OF (ADA83_VERSION_MINOR) \
@@ -63815,17 +63846,30 @@ int Native_Backend_Compile (const char *ir_path, const char *const *extra_ir,
 #ifdef _WIN32
   const char *drivers[] = { configured, "clang -fuse-ld=lld", "zig cc", "cc",
                             "clang", "gcc" };
-  const char *link_libraries = "-lm -lapi-ms-win-core-synch-l1-2-0";
+  // Synchronization.lib is the import library Microsoft documents for
+  // WaitOnAddress, and the only one that exists in every toolchain: mingw-w64
+  // ships libsynchronization.a but no libapi-ms-win-core-synch-l1-2-0.a at
+  // all, so naming the API set directly cannot link under gcc or clang there.
+  const char *link_libraries = "-lm -lsynchronization";
+  // A PE image carries its own stack reserve, 1 MiB under lld and 2 MiB under
+  // mingw ld, where getrlimit(RLIMIT_STACK) reports 8 MiB on Linux and so does
+  // pthread_get_stacksize_np() for the main thread on macOS. The stack probe
+  // reads that reserve back through GetCurrentThreadStackLimits(), and threads
+  // created with no explicit size inherit it, so a frame the other two
+  // platforms have room for raises STORAGE_ERROR here. Ask for the same 8 MiB
+  // and the probe agrees on all three.
+  const char *link_options = "-Wl,--stack,8388608";
 #else
   const char *drivers[] = { configured, "cc", "clang", "gcc" };
   const char *link_libraries = "-lm -lpthread";
+  const char *link_options = "";
 #endif
   bool driver_ran = false;
   for (size_t i = 0; i < sizeof drivers / sizeof *drivers; i++) {
     if (not drivers[i]) continue;
     char command[PATH_MAX * 3];
-    snprintf (command, sizeof command, "%s \"%s\" -o \"%s\" %s",
-              drivers[i], obj_path, exe_path, link_libraries);
+    snprintf (command, sizeof command, "%s \"%s\" -o \"%s\" %s %s",
+              drivers[i], obj_path, exe_path, link_libraries, link_options);
     int exit_status = Host_Command_Exit_Status (system (command));
     if (exit_status == 127) continue;
 #ifdef _WIN32


### PR DESCRIPTION
This patch contains fixes for MacOS and Windows builds.

MacOS:
 * stdin, stdout, and stderr had architecture specific names
 * LongJump was failing on AARCH64.

Windows:
 * llvm's linker `lld` used 1MB default stack size where as `gcc`'s `ld`  uses 8MB. We needed about 1.4MB which crashed the linker in some cases. 
  * in `Text_IO` flushing a stream that isn't writing is undefined behavior. It passed on gcc but not on clang because on clang flushing a reading stream caused it to skip to the end of the pending input where as on gcc it did not modify stream position. Now we prevent flushing read only stream.
