### PR TITLE
Keep "/=" its own operator when it resolves to a renamed "="

### DIFF
--- a/ada83.c
+++ b/ada83.c
@@ -44588,7 +44588,10 @@ Value Lower_Expression (Node *node) {
 
       if (call_target and call_target != node->symbol and call_target->is_predefined) {
         Token_Kind override = Token_From_Op_Name (call_target->name);
-        if (override != TK_EOF and override != node->binary.op) {
+        bool inequality_of_equality =
+          node->binary.op == TK_NE and override == TK_EQ;
+        if (override != TK_EOF and override != node->binary.op and
+            not inequality_of_equality) {
           Node tmp  = *node;
           tmp.binary.op    = override;
           return Emit_Binary_Op_Predefined (&tmp);


### PR DESCRIPTION
The setup: why a renaming is involved at all

In Ada 83 you may not write your own = for an ordinary type. This is illegal:

`function "=" (Left, Right : Thing) return Boolean is ...   -- rejected`

(The compiler reports this: "an explicit declaration of = is only allowed if both parameters are of the same limited type".)

But a renaming is allowed. It just gives an existing operator a second name in your scope:

    --  Long is declared in another package, Nums.
    --  Its "=" isn't directly visible here, so borrow it under the name "=".
    function "=" (Left, Right : Long) return Boolean renames Nums."=";

When you declare `=`, Ada automatically gives you `/=` as its opposite. You never write `/=` yourself; it comes along for free, defined as "not equal."

So after that one renaming line, both of these work:

    if A =  B then ...   -- the renamed "="
    if A /= B then ...   -- the "/=" that came with it, meaning "not (A = B)"

How the compiler finds `/=`

Here's the key move. When the compiler sees `A /= B`, it looks for candidate subprograms named `/=` — and also named `=`, precisely because `/=` is often just "the one that came with =". That's this line in `ada83.c`:

    if (op == TK_NE) names[name_count++] = S("=");   // for "/=", also look for "="

So resolution finishes in this state:

- the syntax node says `/= (node->binary.op == TK_NE)`
- the thing it resolved to is named `=`

That's normal and correct. The node means: call that `=`, then flip the answer.

The bug

Later, when generating code, there was this step:

    Token_Kind override = Token_From_Op_Name (call_target->name);  // "=" → TK_EQ
    if (override != TK_EOF and override != node->binary.op) {
       Node tmp = *node;
       tmp.binary.op = override;                  // /= is overwritten with =
       return Emit_Binary_Op_Predefined (&tmp);   // emits an equality
    }

It saw "the node says `/=` but the target is named `=`" and concluded "the target must be right — make it `=`." The flip was never applied. `A /= B` compiled into `A = B`.

Worked example — this program printed the wrong line:

    A : constant Long := 5;
    B : constant Long := 5;
    ...
    if A /= B then
       Put_Line ("/= says unequal (WRONG)");    -- ← this printed
    else
       Put_Line ("/= says equal (correct)");
    end if;

Because both are 5, the compiler even folded it at compile time, and you could see the wrong answer sitting in the generated code:

    %t10 = add i8 0, 1  ; static comparison (exact)   ← A =  B  → 1, correct
    %t24 = add i8 0, 1  ; static comparison (exact)   ← A /= B  → 1, WRONG (should be 0)

In no_build it looked like this. `Write_File` checks that it wrote everything:

    Put := C_Fwrite (...);                    -- returns 1, one byte written
    if Put /= Long (Contents'Length) then     -- 1 /= 1  →  should be False
       Panic ("Write_File: short write to " & Path);
    end if;

`1 /= 1` came out `True`, so it reported a short write — on a file it had just written perfectly. That's what made the test suite blow up, and it's the nasty kind of bug: no crash, no diagnostic, just a comparison quietly answering backwards.

Why that rewrite existed (it isn't nonsense)

A renaming can genuinely map one operator onto a different one:

function "<" (Left, Right : Long) return Boolean renames Nums.">";

Now A < B really should emit a greater-than. Here "trust the target's name" is exactly right, and that's what the rewrite is for.

Emit_Binary_Op_Predefined should emit the right operator - The two situations are different:


| Source                      | Resolves to | Does the target name the operation? |
| --------------------------- | ----------- | ----------------------------------- |
| A < B with "<" renaming ">" | >           | Yes — emit >                        |
| A /= B with a renamed "="   | =           | No — = is only where /= came from   |


Predefined `/=` is already exactly the complement of `=`, so for the second row the node already holds the right operation. The fix is to leave it alone:

    bool inequality_of_equality =
      node->binary.op == TK_NE and override == TK_EQ;
    if (override != TK_EOF and override != node->binary.op and
        not inequality_of_equality) {
       ... rewrite ...      // still happens for  "<" renaming ">"
    }

the folder now produces the answer directly instead of computing the wrong one and flipping it:

    %t24 = add i8 0, 0  ; static comparison (exact)   ← correct, no XOR needed

Verified: `/=` both ways (folded and at runtime), `"<"` renaming `">"` still emitting `>`, ordinary `/=` on enumerations and strings untouched, ACATS 3561/3561, extensions 9/9.