### PR TITLE
Fix link driver external name runtime

### DIFF
--- a/ada83-manual.md
+++ b/ada83-manual.md
@@ -15522,6 +15522,224 @@ appendix F for a given implementation must list in particular:
 8. Any implementation-dependent characteristics of the input-output packages
    (see [14](#14-input-output)).
 
+### F.1 Implementation-dependent pragmas
+
+This section states, for each pragma defined by this implementation, its form,
+the places it is allowed, and its effect. It answers item 1 above.
+
+Every pragma in this section is allowed wherever
+[2.8](#28-pragmas) allows a pragma, except where noted otherwise. A pragma
+that names an entity takes effect only where that entity is visible and is
+named after its declaration; otherwise the pragma has no effect.
+
+Argument identifiers are shown in upper case. An argument shown as a
+lower-case syntactic category with no identifier is positional; a named
+association written for such an argument has no effect.
+
+The conventions named by pragma IMPORT, pragma EXPORT and pragma CONVENTION
+are:
+
+| Convention | Effect |
+|---|---|
+| `C` | recorded on the entity |
+| `STDCALL` | recorded on the entity; the targets this implementation generates code for pass arguments identically under `C` and `STDCALL`, so the two select the same sequence |
+| `INTRINSIC` | recorded on the entity; the entity is excluded from the list of subprograms referenced across a subunit boundary, and a generic instance whose template carries this convention carries it also |
+
+An identifier other than these three leaves the entity's convention as it was.
+The convention of an entity named by no such pragma is `ADA`.
+
+The name presented to the linker for an entity with no external name is formed
+as follows:
+
+| Entity | Link name |
+|---|---|
+| library subprogram | `_ada_` followed by the subprogram's name in lower case |
+| subprogram declared in a package | the package name, `__`, the subprogram name, and `_s` followed by a decimal number derived from the parameter and result types |
+| package elaboration procedure | the package name followed by `___elab` |
+
+The decimal suffix distinguishes overloaded subprograms; two subprograms of
+the same profile in different packages carry the same suffix.
+
+#### Pragma IMPORT
+
+```
+pragma IMPORT (CONVENTION => convention, ENTITY => entity
+               [, EXTERNAL_NAME => string_literal]);
+```
+
+The entity must be a subprogram. Its body is supplied outside this program
+library: no body is required for it in this library, and a call to it is
+compiled as a call to the subprogram named by `EXTERNAL_NAME`.
+
+`EXTERNAL_NAME` must be a string literal. Its value is the name presented to
+the linker. If the argument is omitted, the link name stated above is used. If
+the argument is present and is not a string literal, the argument has no
+effect, the link name stated above is used, and a `pragma-ignored` warning is
+issued.
+
+Pragma INTERFACE of [13.9](#139-interface-to-other-languages) is not provided
+by this implementation. Pragma IMPORT states what pragma INTERFACE states, and
+additionally carries the external name.
+
+#### Pragma EXPORT
+
+```
+pragma EXPORT (CONVENTION => convention, ENTITY => entity
+               [, EXTERNAL_NAME => string_literal]);
+```
+
+Marks the entity as exported and sets its convention. A body is required for
+the entity.
+
+`EXTERNAL_NAME` must be a string literal. Its value is the name under which the
+entity is presented to the linker, and is the name by which a program written
+in another language refers to it. If the argument is omitted, the link name
+stated above is used. If the argument is present and is not a string literal,
+the argument has no effect, the link name stated above is used, and a
+`pragma-ignored` warning is issued.
+
+#### Pragma CONVENTION
+
+```
+pragma CONVENTION (CONVENTION => convention, ENTITY => entity);
+```
+
+Sets the convention of the entity. The entity is neither imported nor
+exported by this pragma.
+
+#### Pragma UNREFERENCED
+
+```
+pragma UNREFERENCED (entity {, entity});
+```
+
+Each entity is a variable, constant, parameter, or a unit named in a with
+clause. No `unused-variable`, `unused-but-set-variable`, `unused-parameter` or
+`unused-with` warning is issued for an entity named by this pragma. The pragma
+has no other effect.
+
+#### Pragma RESTRICTIONS
+
+```
+pragma RESTRICTIONS (restriction {, restriction});
+```
+
+Each restriction is one of:
+
+| Restriction | Constructs rejected |
+|---|---|
+| `NO_SELECT_STATEMENTS` | select statements |
+| `NO_ABORT_STATEMENTS` | abort statements |
+| `NO_TASK_ALLOCATORS` | allocators for task types |
+| `NO_ENTRY_FAMILIES` | entry family declarations |
+
+A restriction is in force from the pragma to the end of the compilation. A
+program containing a construct rejected by a restriction in force is illegal.
+An identifier that is not one of the four is ignored, and a warning is issued.
+
+#### Pragma PROFILE
+
+```
+pragma PROFILE (profile);
+```
+
+`RAVENSCAR` is the only profile defined by this implementation. It puts
+`NO_SELECT_STATEMENTS`, `NO_ABORT_STATEMENTS`, `NO_TASK_ALLOCATORS` and
+`NO_ENTRY_FAMILIES` in force. Any other identifier is ignored, and a warning
+is issued.
+
+#### Pragma PURE, Pragma PREELABORATE
+
+```
+pragma PURE [(unit)];
+pragma PREELABORATE [(unit)];
+```
+
+Marks a package as pure, or as preelaborable. With no argument the pragma
+applies to the package enclosing it.
+
+The mark is recorded in the library information file written for the unit. A
+unit so marked contributes no elaboration dependence to units that name it in
+a with clause. This implementation does not check that the unit obeys the
+rules the mark implies.
+
+#### Pragma ELABORATE_ALL
+
+```
+pragma ELABORATE_ALL (unit {, unit});
+```
+
+Takes effect only in a context clause, following the with clause naming the
+unit. Written elsewhere, the pragma has no effect and no warning is issued.
+
+The body of each named unit, and the body of every unit reachable from it
+through with clauses, is elaborated before the unit to which the context
+clause belongs. Pragma ELABORATE of Annex B requires the same of each named
+unit alone, without the units reachable from it.
+
+### F.2 Language-defined pragmas
+
+The pragmas of Annex B are accepted by this implementation. The following have
+the effect Annex B defines:
+
+| Pragma | Effect |
+|---|---|
+| `ELABORATE` | the body of each named unit is elaborated before the unit to which the context clause belongs |
+| `INLINE` | each named subprogram is marked for inline expansion at its call sites |
+| `PACK` | components of the named array or record type are allocated without gaps, and the type's size is set to the total so obtained |
+| `SUPPRESS` | the named check is omitted |
+
+Pragma SUPPRESS accepts the check names `ACCESS_CHECK`, `DISCRIMINANT_CHECK`,
+`DIVISION_CHECK`, `ELABORATION_CHECK`, `INDEX_CHECK`, `LENGTH_CHECK`,
+`OVERFLOW_CHECK`, `RANGE_CHECK` and `STORAGE_CHECK`, and additionally accepts
+`ALL_CHECKS`, which names all nine. Written without its `ON` argument, the
+pragma omits the check over the region in which it appears, or over the
+compilation when it appears at the outermost level. Written with its `ON`
+argument, the permission is recorded against the named entity; it is applied
+where a check is generated for that entity and is not applied where a check is
+generated for a subtype or a region.
+
+The same checks may be omitted for a whole compilation with the `--suppress`
+option of the compiler, which takes the same names.
+
+Pragma INLINE marks the subprogram for inline expansion. Whether a given call
+is expanded is determined by the code generator, which takes the mark as one
+input; the pragma does not require expansion and its absence does not prevent
+it.
+
+The following pragmas of Annex B are accepted, are not diagnosed, and are not
+yet implemented: `CONTROLLED`, `INTERFACE`, `LIST`, `MEMORY_SIZE`, `OPTIMIZE`,
+`PAGE`, `PRIORITY`, `SHARED`, `STORAGE_UNIT`, `SYSTEM_NAME`.
+
+### F.3 Pragma arguments
+
+[2.8](#28-pragmas) admits a named association only where the argument
+identifier is defined. The argument identifiers defined by this implementation
+are `CONVENTION`, `ENTITY` and `EXTERNAL_NAME`, on the pragmas shown in
+[F.1](#f1-implementation-dependent-pragmas). No other pragma of this
+implementation defines an argument identifier. No argument identifier is
+defined here for a pragma of Annex B beyond those Annex B defines.
+
+An argument is matched to a formal by name where an argument identifier is
+given, and by position otherwise. Where the same formal is named more than
+once, the first association is used, the later ones have no effect, and a
+`pragma-ignored` warning is issued for each.
+
+In accordance with 2.8, a pragma whose arguments do not correspond to its form
+has no effect and is not illegal. Two warning classes report such a pragma:
+
+| Class | Reported when |
+|---|---|
+| `unrecognized-pragma` | the pragma identifier is not one this implementation recognizes |
+| `pragma-ignored` | the pragma identifier is recognized and an argument does not correspond, so that the argument, or the pragma, has no effect |
+
+Both classes are enabled by default and are turned off with
+`-Wno-unrecognized-pragma` and `-Wno-pragma-ignored`. The identifiers this
+implementation recognizes are the fourteen of Annex B and the nine of
+[F.1](#f1-implementation-dependent-pragmas).
+
+No pragma defined by this implementation determines the legality of any text
+outside the pragma itself.
 ---
 
 ## Rationale

--- a/ada83.c
+++ b/ada83.c
@@ -23092,7 +23092,12 @@ Node *Find_Pragma_Named_Argument (Node_List *args, Slice formal) {
       Node *choice = arg->association.choices.items[c];
       if (not choice or choice->kind != NK_IDENTIFIER) continue;
       if (not Slices_Match (choice->string_val.text, formal)) continue;
-      if (not found) found = arg->association.expression;
+      if (found)
+        Note_Pending_Warning (WARNING_PRAGMA_IGNORED, arg->location,
+          "'%.*s' is given more than once in this pragma; this one has no "
+          "effect", (int) formal.length, formal.data);
+      else
+        found = arg->association.expression;
     }
   }
   return found;

--- a/ada83.c
+++ b/ada83.c
@@ -63938,6 +63938,61 @@ bool Llvm_C_Api_Load (Llvm_C_Api *api, char *err, size_t err_size) {
   return true;
 }
 
+
+#define MAX_LINKER_ARGUMENTS 128
+
+bool Push_Linker_Word (const char *word, char *pool, size_t pool_size,
+                       size_t *pool_used, const char **argv, int *argc) {
+  if (not word) return true;
+  size_t length = strlen (word);
+  if (*pool_used + length + 1 > pool_size) return false;
+  if (*argc + 1 >= MAX_LINKER_ARGUMENTS) return false;
+  char *slot = pool + *pool_used;
+  memcpy (slot, word, length + 1);
+  *pool_used += length + 1;
+  argv[(*argc)++] = slot;
+  return true;
+}
+
+bool Push_Linker_Words (const char *text, char *pool, size_t pool_size,
+                        size_t *pool_used, const char **argv, int *argc) {
+  if (not text) return true;
+  const char *cursor = text;
+  while (*cursor) {
+    while (*cursor == ' ') cursor++;
+    if (not *cursor) break;
+    const char *start = cursor;
+    while (*cursor and *cursor != ' ') cursor++;
+    size_t length = (size_t) (cursor - start);
+    if (*pool_used + length + 1 > pool_size) return false;
+    if (*argc + 1 >= MAX_LINKER_ARGUMENTS) return false;
+    char *slot = pool + *pool_used;
+    memcpy (slot, start, length);
+    slot[length] = '\0';
+    *pool_used += length + 1;
+    argv[(*argc)++] = slot;
+  }
+  return true;
+}
+
+int Run_Linker_Driver (const char **argv) {
+#ifdef _WIN32
+  intptr_t result = _spawnvp (_P_WAIT, argv[0], (const char *const *) argv);
+  if (result == -1) return 127;
+  return (int) result;
+#else
+  pid_t child = fork ();
+  if (child < 0) return 127;
+  if (child == 0) {
+    execvp (argv[0], (char *const *) argv);
+    _exit (127);
+  }
+  int wait_status = 0;
+  if (waitpid (child, &wait_status, 0) < 0) return 127;
+  return Host_Command_Exit_Status (wait_status);
+#endif
+}
+
 int Native_Backend_Compile (const char *ir_path, const char *const *extra_ir,
                             int extra_count, const char *exe_path,
                             const Native_Backend_Options *options) {
@@ -64054,10 +64109,26 @@ int Native_Backend_Compile (const char *ir_path, const char *const *extra_ir,
   bool driver_ran = false;
   for (size_t i = 0; i < sizeof drivers / sizeof *drivers; i++) {
     if (not drivers[i]) continue;
-    char command[PATH_MAX * 3];
-    snprintf (command, sizeof command, "%s \"%s\" -o \"%s\" %s %s",
-              drivers[i], obj_path, exe_path, link_libraries, link_options);
-    int exit_status = Host_Command_Exit_Status (system (command));
+
+    const char *argv[MAX_LINKER_ARGUMENTS];
+    char        pool[PATH_MAX * 4];
+    int         argc = 0;
+    size_t      used = 0;
+
+    bool built =
+      Push_Linker_Words (drivers[i],      pool, sizeof pool, &used, argv, &argc) and
+      Push_Linker_Word  (obj_path,        pool, sizeof pool, &used, argv, &argc) and
+      Push_Linker_Word  ("-o",            pool, sizeof pool, &used, argv, &argc) and
+      Push_Linker_Word  (exe_path,        pool, sizeof pool, &used, argv, &argc) and
+      Push_Linker_Words (link_libraries,  pool, sizeof pool, &used, argv, &argc) and
+      Push_Linker_Words (link_options,    pool, sizeof pool, &used, argv, &argc);
+    if (not built) {
+      Report_Driver_Error ("the link command is too long");
+      break;
+    }
+    argv[argc] = NULL;
+
+    int exit_status = Run_Linker_Driver (argv);
     if (exit_status == 127) continue;
 #ifdef _WIN32
     if (exit_status == 9009) continue;

--- a/ada83.c
+++ b/ada83.c
@@ -752,7 +752,8 @@ void Report_Driver_Warning (const char *format, ...)
   _ (WARNING_DEAD_STORE,              "dead-store")              \
   _ (WARNING_CONSTRAINT_ERROR,        "constraint-error")        \
   _ (WARNING_READ_BEFORE_ASSIGNMENT,  "read-before-assignment")  \
-  _ (WARNING_REDUNDANT_WITH,          "redundant-with")
+  _ (WARNING_REDUNDANT_WITH,          "redundant-with")          \
+  _ (WARNING_PRAGMA_IGNORED,          "pragma-ignored")
 
 typedef enum {
 #define _(kind, name) kind,
@@ -23081,11 +23082,43 @@ void Derive_Subprograms (Type *derived_type,
     }
 }
 
+Node *Find_Pragma_Named_Argument (Node_List *args, Slice formal) {
+  Node *found = NULL;
+  for (u32 i = 0; i < args->count; i++) {
+    Node *arg = args->items[i];
+    if (not arg or arg->kind != NK_ASSOCIATION) continue;
+    for (u32 c = 0; c < arg->association.choices.count; c++) {
+      Node *choice = arg->association.choices.items[c];
+      if (not choice or choice->kind != NK_IDENTIFIER) continue;
+      if (not Slices_Match (choice->string_val.text, formal)) continue;
+      if (not found) found = arg->association.expression;
+    }
+  }
+  return found;
+}
+
+Node *Pragma_Argument (Node_List *args, Slice formal, u32 position) {
+  Node *named = Find_Pragma_Named_Argument (args, formal);
+  if (named) return named;
+  if (position >= args->count) return NULL;
+  Node *supplied = args->items[position];
+  if (supplied and supplied->kind == NK_ASSOCIATION and
+      supplied->association.choices.count > 0)
+    return NULL;
+  return supplied;
+}
+
 void Apply_Pragma_External_Name (Symbol *sym, Node_List *args) {
-  if (args->count < 3) return;
-  Node *name_node = Unwrap_Association (args->items[2]);
+  Node *supplied = Pragma_Argument (args, S ("EXTERNAL_NAME"), 2);
+  if (not supplied) return;
+  Node *name_node = Unwrap_Association (supplied);
   if (name_node and name_node->kind == NK_STRING)
     sym->external_name = name_node->string_val.text;
+  else
+    Note_Pending_Warning (WARNING_PRAGMA_IGNORED, supplied->location,
+      "the external name must be a string literal, so this argument has no "
+      "effect and '%.*s' keeps its Ada name",
+      (int) sym->name.length, sym->name.data);
 }
 
 void Apply_Pragma_Convention (Symbol *sym, Node *conv_node) {
@@ -23100,10 +23133,10 @@ void Apply_Pragma_Convention (Symbol *sym, Node *conv_node) {
 }
 
 Symbol *Find_Pragma_Entity (Node_List *arguments, Node **out_convention) {
-  *out_convention = NULL;
-  if (arguments->count < 2) return NULL;
-  *out_convention = Unwrap_Association (arguments->items[0]);
-  Node *entity = Unwrap_Association (arguments->items[1]);
+  *out_convention = Unwrap_Association (
+    Pragma_Argument (arguments, S ("CONVENTION"), 0));
+  Node *entity = Unwrap_Association (
+    Pragma_Argument (arguments, S ("ENTITY"), 1));
   if (not (entity and entity->kind == NK_IDENTIFIER)) return NULL;
   return Symbol_Find (entity->string_val.text);
 }

--- a/ada83.c
+++ b/ada83.c
@@ -32045,7 +32045,8 @@ Slice Get_Emitted_Name (Symbol *sym) {
 
   while (sym->aliased) sym = sym->aliased;
 
-  if (sym->is_imported and sym->external_name.length > 0) {
+  if ((sym->is_imported or sym->is_exported) and
+      sym->external_name.length > 0) {
     Slice name = sym->external_name;
     if (name.length >= 2 and name.data[0] == '"' and name.data[name.length - 1] == '"') {
       name.data++;

--- a/ada83.c
+++ b/ada83.c
@@ -50466,6 +50466,7 @@ void Lower_Subprogram_Body (Node *node) {
           Spell_Return_Rep (sym));
     Emit_Symbol_Name (sym);
     Emit_Formal_Parameter_List (sym, is_nested, true);
+    if (sym and sym->is_inline) Emit (" inlinehint");
     Emit (" {\n");
     Function_Body_Begin ();
 

--- a/ada83.c
+++ b/ada83.c
@@ -753,7 +753,8 @@ void Report_Driver_Warning (const char *format, ...)
   _ (WARNING_CONSTRAINT_ERROR,        "constraint-error")        \
   _ (WARNING_READ_BEFORE_ASSIGNMENT,  "read-before-assignment")  \
   _ (WARNING_REDUNDANT_WITH,          "redundant-with")          \
-  _ (WARNING_PRAGMA_IGNORED,          "pragma-ignored")
+  _ (WARNING_PRAGMA_IGNORED,          "pragma-ignored")          \
+  _ (WARNING_UNRECOGNIZED_PRAGMA,     "unrecognized-pragma")
 
 typedef enum {
 #define _(kind, name) kind,
@@ -24041,6 +24042,22 @@ void Resolve_Subprogram_Renaming (Node *node) {
   node->symbol = sym;
 }
 
+bool Pragma_Name_Is_Known (Slice name) {
+  static const char *const known[] = {
+    "CONTROLLED",   "ELABORATE",     "INLINE",    "INTERFACE",
+    "LIST",         "MEMORY_SIZE",   "OPTIMIZE",  "PACK",
+    "PAGE",         "PRIORITY",      "SHARED",    "STORAGE_UNIT",
+    "SUPPRESS",     "SYSTEM_NAME",
+    "CONVENTION",   "ELABORATE_ALL", "EXPORT",    "IMPORT",
+    "PREELABORATE", "PROFILE",       "PURE",      "RESTRICTIONS",
+    "UNREFERENCED"
+  };
+  for (u32 i = 0; i < sizeof known / sizeof known[0]; i++)
+    if (Slices_Match (name, (Slice){ known[i], (u32) strlen (known[i]) }))
+      return true;
+  return false;
+}
+
 void Resolve_Pragma (Node *node) {
   Node_List   *arguments = &node->pragma_node.arguments;
   Slice name      = node->pragma_node.name;
@@ -24180,6 +24197,11 @@ void Resolve_Pragma (Node *node) {
       if (pure) unit->is_pure_unit = true;
       else      unit->is_preelaborate_unit = true;
     }
+
+  } else if (not Pragma_Name_Is_Known (name)) {
+    Note_Pending_Warning (WARNING_UNRECOGNIZED_PRAGMA, node->location,
+      "unrecognized pragma '%.*s' ignored",
+      (int) name.length, name.data);
   }
 }
 

--- a/makefile
+++ b/makefile
@@ -138,6 +138,7 @@ BIN_DIRS         = bin-linux bin-macos bin-windows
 LIBRARY_SOURCE   = bin-dll.zip
 EXECUTABLE       = ada83$(SUFFIX)
 HOST_BINARY      = bin-$(HOST_TARGET)/ada83
+HOST_RUNTIME     = bin-$(HOST_TARGET)/$(RUNTIME)
 RESOURCE_OBJECT  = $(if $(RESOURCE_COMPILER),staging/$(ICON).o)
 
 LIPO := $(shell command -v lipo || command -v llvm-lipo || \
@@ -146,13 +147,18 @@ SUDO := $(shell [ $$(id -u) -eq 0 ] || echo sudo)
 
 all: ada83 provision-llvm
 
-ada83: $(HOST_BINARY)
+ada83: $(HOST_BINARY) $(HOST_RUNTIME)
 
 $(HOST_BINARY): ada83.c
 	@mkdir -p $(@D)
 	@$(call STAGE,compiling ada83.c with $(CC))
 	$(CC) $(CFLAGS) $(WHOLE_PROGRAM) $(TUNE) -o $@ $< $(LIBS)
 	@echo "Built $@."
+
+$(HOST_RUNTIME): $(RUNTIME)
+	@mkdir -p $(@D)
+	@$(call STAGE,copying $(RUNTIME) beside the compiler)
+	cp $< $@
 
 provision-llvm:
 	@$(LLVM_PRESENT) && exit 0; \


### PR DESCRIPTION
I extracted the useful bugfixes from the experimental branch. Here are the fixes:

1. It's certainly not the end of the world problem as downloading a repo and running their build script can run arbitrary code on your system, or the built binary can run arbitrary code on your system, but there was some surprising behavior that let you inject commands to be run in the linker:

    ada83 -I. hello.ada -o 'out$(touch shell_ran).bin'

This is furthermore a problem if we want to add `pragma Linker_Options ("-lm", )` as it opens the door to `pragma Linker_Options ("-lm", ";sudo rm -rf /;"); or other arbitrary code executions just from compiling the source code. Instead of building the linker command and passing it to system() we instead use fork and execvp, or _spawnvp on Windows, with an argv array.

2. Whenever you compile the compiler, ensure we copy the runtime copied alongside. This should have been happening before as they are a pair and belong together. This prevents issues like stale runtimes, or building the compiler+extension but it doesn't have the runtime copied alongside so basic standard library packages appear undeclared.

3. pragma Import and pragma Export took their external name from the third positional argument, and only when it was a string literal. RM 2.8 states if Named arguments are provided only named arguments will be allowed, then positional arguments should be allowed. This is the case for all pragmas.

4. pragma Inline did nothing. It now it adds llvm `inlinehint` to the IR.

5. pragma Export's external name did not apply.